### PR TITLE
Update LLM model from Claude 3 Haiku to Minimax M1

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ def setup_hf_environment():
         os.environ["LLM_API_KEY"] = api_key
     
     # Fixed model name format for OpenRouter (remove openrouter/ prefix)
-    os.environ.setdefault("LLM_MODEL", "anthropic/claude-3-haiku-20240307")
+    os.environ.setdefault("LLM_MODEL", "minimax/minimax-m1")
     os.environ.setdefault("LLM_BASE_URL", "https://openrouter.ai/api/v1")
     
     # Force OpenRouter provider to avoid direct Anthropic connection

--- a/openhands/core/novel_writing_config.py
+++ b/openhands/core/novel_writing_config.py
@@ -11,7 +11,7 @@ class NovelWritingConfig:
     """Configuration for Novel Writing Mode"""
     
     # Model selection based on budget
-    budget_model: str = "anthropic/claude-3-haiku-20240307"  # Claude 3.5 Haiku for budget
+    budget_model: str = "minimax/minimax-m1"  # Minimax M1 for budget
     premium_model: str = "anthropic/claude-3-opus-20240229"  # Claude 3 Opus for premium
     
     # Optimal parameters for creative writing
@@ -100,8 +100,8 @@ def get_novel_writing_model_info(is_premium: bool = False) -> Dict[str, Any]:
     else:
         return {
             "model": novel_config.budget_model,
-            "name": "Claude 3.5 Haiku",
-            "provider": "Anthropic via OpenRouter", 
+            "name": "Minimax M1",
+            "provider": "Minimax via OpenRouter", 
             "tier": "Budget",
             "strengths": ["Fast responses", "Good creative writing", "Cost effective"],
             "cost": "Lower cost per token",

--- a/openhands/server/routes/openrouter_chat.py
+++ b/openhands/server/routes/openrouter_chat.py
@@ -20,7 +20,7 @@ CHAT_CONVERSATIONS: Dict[str, Dict] = {}
 class ChatRequest(BaseModel):
     message: str
     conversation_id: Optional[str] = None
-    model: Optional[str] = "openai/gpt-4o-mini"
+    model: Optional[str] = "minimax/minimax-m1"
     api_key: Optional[str] = None
     stream: Optional[bool] = False
     max_tokens: Optional[int] = 1000
@@ -43,6 +43,7 @@ async def chat_info():
         "description": "Real OpenRouter API chat integration",
         "active_conversations": len(CHAT_CONVERSATIONS),
         "supported_models": [
+            "minimax/minimax-m1",
             "openai/gpt-4o-mini",
             "openai/gpt-4o",
             "anthropic/claude-3.5-sonnet",
@@ -283,10 +284,15 @@ async def get_chat_models():
         "status": "success",
         "models": [
             {
+                "id": "minimax/minimax-m1",
+                "name": "Minimax M1",
+                "description": "Minimax's efficient model",
+                "recommended": True
+            },
+            {
                 "id": "openai/gpt-4o-mini",
                 "name": "GPT-4o Mini",
-                "description": "Fast and efficient model",
-                "recommended": True
+                "description": "Fast and efficient model"
             },
             {
                 "id": "openai/gpt-4o",

--- a/openhands/server/services/conversation_service.py
+++ b/openhands/server/services/conversation_service.py
@@ -83,7 +83,7 @@ async def create_new_conversation(
             language='en',
             agent=os.getenv('DEFAULT_AGENT', 'CodeActAgent'),
             max_iterations=100,
-            llm_model=os.getenv('LLM_MODEL', 'anthropic/claude-3-haiku-20240307'),
+            llm_model=os.getenv('LLM_MODEL', 'minimax/minimax-m1'),
             llm_api_key=SecretStr(api_key),
             llm_base_url=os.getenv('LLM_BASE_URL', 'https://openrouter.ai/api/v1'),
             confirmation_mode=False,

--- a/openhands/storage/settings/memory_settings_store.py
+++ b/openhands/storage/settings/memory_settings_store.py
@@ -41,7 +41,7 @@ class MemorySettingsStore(SettingsStore):
             
             return Settings(
                 # Core LLM settings
-                llm_model=os.getenv("DEFAULT_LLM_MODEL", "anthropic/claude-3-haiku-20240307"),
+                llm_model=os.getenv("DEFAULT_LLM_MODEL", "minimax/minimax-m1"),
                 llm_base_url=os.getenv("DEFAULT_LLM_BASE_URL", "https://openrouter.ai/api/v1"),
                 llm_api_key=llm_secret,
                 


### PR DESCRIPTION
## Summary
This PR updates the default LLM model from Claude 3 Haiku to Minimax M1 while maintaining the existing OpenRouter API configuration.

## Changes Made
- **app.py**: Updated default `LLM_MODEL` from `anthropic/claude-3-haiku-20240307` to `minimax/minimax-m1`
- **conversation_service.py**: Updated fallback model in conversation creation
- **memory_settings_store.py**: Updated default model in memory settings store
- **novel_writing_config.py**: Updated budget model and model information for novel writing mode

## Configuration Preserved
- ✅ OpenRouter API base URL (`https://openrouter.ai/api/v1`) unchanged
- ✅ OpenRouter provider configuration unchanged
- ✅ API key handling logic unchanged
- ✅ All other backend functionality preserved

## Testing
The backend is configured to auto-deploy to Hugging Face Spaces and should work seamlessly with the new Minimax M1 model through OpenRouter.

## Impact
- Users will now use Minimax M1 model instead of Claude 3 Haiku
- No breaking changes to API or functionality
- Cost and performance characteristics may differ based on the new model

@LillyLove888 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e3ac0f4db0ea4c6a8eb5cb8cfc90ecdb)