### PR TITLE
Fix deployment configuration for Minimax M1 model

### DIFF
--- a/.env.hf
+++ b/.env.hf
@@ -17,7 +17,7 @@ WORKSPACE_BASE=/tmp/workspace
 
 # LLM Configuration (SET THESE IN HF SPACE SETTINGS)
 # LLM_API_KEY=your_openrouter_api_key
-# LLM_MODEL=openrouter/anthropic/claude-3-haiku-20240307
+# LLM_MODEL=minimax/minimax-m1
 # LLM_BASE_URL=https://openrouter.ai/api/v1
 
 # Optional (JWT_SECRET will be auto-generated if not provided)

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV DISABLE_PERSISTENT_SESSIONS=true
 ENV SERVE_FRONTEND=false
 
 # Set default LLM configuration
-ENV LLM_MODEL=openrouter/anthropic/claude-3-haiku-20240307
+ENV LLM_MODEL=minimax/minimax-m1
 ENV LLM_BASE_URL=https://openrouter.ai/api/v1
 
 # Expose port (HF Spaces requires 7860)


### PR DESCRIPTION
## 🔧 Fix Deployment Configuration Issues

This PR addresses deployment configuration inconsistencies that were causing model ID validation errors in Hugging Face Spaces.

### 🐛 **Problem**
- HF Spaces deployment was failing with `openrouter/anthropic/claude-3-haiku-20240307 is not a valid model ID`
- Deployment configuration files still referenced the old Claude model
- Runtime code was updated to Minimax M1, but deployment configs were not

### ✅ **Changes Made**
- **`.env.hf`**: Updated LLM_MODEL from `openrouter/anthropic/claude-3-haiku-20240307` to `minimax/minimax-m1`
- **`Dockerfile`**: Updated ENV LLM_MODEL from `openrouter/anthropic/claude-3-haiku-20240307` to `minimax/minimax-m1`

### 🎯 **Impact**
- Resolves model ID validation errors in HF Spaces
- Ensures consistent model configuration across all deployment files
- Maintains OpenRouter API integration unchanged
- Completes the migration from Claude to Minimax M1

### 📋 **Additional Notes**
- This follows up on the previous PR that updated runtime code
- HF Spaces environment variables may need manual update in the Space settings
- All OpenRouter API configurations remain unchanged

### ✅ **Testing**
- Deployment configuration files now consistently reference `minimax/minimax-m1`
- No breaking changes to existing API endpoints
- Maintains backward compatibility with OpenRouter integration

@LillyLove888 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e3ac0f4db0ea4c6a8eb5cb8cfc90ecdb)