### PR TITLE
Switch to Claude 3.5 Sonnet for better conversation quality

### DIFF
--- a/.env.hf
+++ b/.env.hf
@@ -17,7 +17,7 @@ WORKSPACE_BASE=/tmp/workspace
 
 # LLM Configuration (SET THESE IN HF SPACE SETTINGS)
 # LLM_API_KEY=your_openrouter_api_key
-# LLM_MODEL=minimax/minimax-m1
+# LLM_MODEL=anthropic/claude-3.5-sonnet
 # LLM_BASE_URL=https://openrouter.ai/api/v1
 
 # Optional (JWT_SECRET will be auto-generated if not provided)

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV DISABLE_PERSISTENT_SESSIONS=true
 ENV SERVE_FRONTEND=false
 
 # Set default LLM configuration
-ENV LLM_MODEL=minimax/minimax-m1
+ENV LLM_MODEL=anthropic/claude-3.5-sonnet
 ENV LLM_BASE_URL=https://openrouter.ai/api/v1
 
 # Expose port (HF Spaces requires 7860)

--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ def setup_hf_environment():
         os.environ["LLM_API_KEY"] = api_key
     
     # Fixed model name format for OpenRouter (remove openrouter/ prefix)
-    os.environ.setdefault("LLM_MODEL", "minimax/minimax-m1")
+    os.environ.setdefault("LLM_MODEL", "anthropic/claude-3.5-sonnet")
     os.environ.setdefault("LLM_BASE_URL", "https://openrouter.ai/api/v1")
     
     # Force OpenRouter provider to avoid direct Anthropic connection

--- a/openhands/core/novel_writing_config.py
+++ b/openhands/core/novel_writing_config.py
@@ -11,7 +11,7 @@ class NovelWritingConfig:
     """Configuration for Novel Writing Mode"""
     
     # Model selection based on budget
-    budget_model: str = "minimax/minimax-m1"  # Minimax M1 for budget
+    budget_model: str = "anthropic/claude-3.5-sonnet"  # Claude 3.5 Sonnet for quality
     premium_model: str = "anthropic/claude-3-opus-20240229"  # Claude 3 Opus for premium
     
     # Optimal parameters for creative writing

--- a/openhands/server/routes/openrouter_chat.py
+++ b/openhands/server/routes/openrouter_chat.py
@@ -20,7 +20,7 @@ CHAT_CONVERSATIONS: Dict[str, Dict] = {}
 class ChatRequest(BaseModel):
     message: str
     conversation_id: Optional[str] = None
-    model: Optional[str] = "minimax/minimax-m1"
+    model: Optional[str] = "anthropic/claude-3.5-sonnet"
     api_key: Optional[str] = None
     stream: Optional[bool] = False
     max_tokens: Optional[int] = 1000
@@ -43,11 +43,11 @@ async def chat_info():
         "description": "Real OpenRouter API chat integration",
         "active_conversations": len(CHAT_CONVERSATIONS),
         "supported_models": [
-            "minimax/minimax-m1",
+            "anthropic/claude-3.5-sonnet",
             "openai/gpt-4o-mini",
             "openai/gpt-4o",
-            "anthropic/claude-3.5-sonnet",
             "anthropic/claude-3-haiku",
+            "minimax/minimax-m1",
             "google/gemini-pro",
             "meta-llama/llama-3.1-8b-instruct"
         ],
@@ -284,9 +284,9 @@ async def get_chat_models():
         "status": "success",
         "models": [
             {
-                "id": "minimax/minimax-m1",
-                "name": "Minimax M1",
-                "description": "Minimax's efficient model",
+                "id": "anthropic/claude-3.5-sonnet",
+                "name": "Claude 3.5 Sonnet",
+                "description": "Anthropic's most capable model for natural conversations",
                 "recommended": True
             },
             {
@@ -300,14 +300,14 @@ async def get_chat_models():
                 "description": "Most capable OpenAI model"
             },
             {
-                "id": "anthropic/claude-3.5-sonnet",
-                "name": "Claude 3.5 Sonnet",
-                "description": "Anthropic's most capable model"
-            },
-            {
                 "id": "anthropic/claude-3-haiku",
                 "name": "Claude 3 Haiku",
                 "description": "Fast and efficient Claude model"
+            },
+            {
+                "id": "minimax/minimax-m1",
+                "name": "Minimax M1",
+                "description": "Minimax's efficient model"
             },
             {
                 "id": "google/gemini-pro",

--- a/openhands/server/services/conversation_service.py
+++ b/openhands/server/services/conversation_service.py
@@ -83,7 +83,7 @@ async def create_new_conversation(
             language='en',
             agent=os.getenv('DEFAULT_AGENT', 'CodeActAgent'),
             max_iterations=100,
-            llm_model=os.getenv('LLM_MODEL', 'minimax/minimax-m1'),
+            llm_model=os.getenv('LLM_MODEL', 'anthropic/claude-3.5-sonnet'),
             llm_api_key=SecretStr(api_key),
             llm_base_url=os.getenv('LLM_BASE_URL', 'https://openrouter.ai/api/v1'),
             confirmation_mode=False,

--- a/openhands/storage/settings/memory_settings_store.py
+++ b/openhands/storage/settings/memory_settings_store.py
@@ -41,7 +41,7 @@ class MemorySettingsStore(SettingsStore):
             
             return Settings(
                 # Core LLM settings
-                llm_model=os.getenv("DEFAULT_LLM_MODEL", "minimax/minimax-m1"),
+                llm_model=os.getenv("DEFAULT_LLM_MODEL", "anthropic/claude-3.5-sonnet"),
                 llm_base_url=os.getenv("DEFAULT_LLM_BASE_URL", "https://openrouter.ai/api/v1"),
                 llm_api_key=llm_secret,
                 


### PR DESCRIPTION
## 🔄 Switch Model: Minimax M1 → Claude 3.5 Sonnet

This PR addresses the template response issue observed with Minimax M1 by switching to Claude 3.5 Sonnet for more natural conversations.

### 🐛 **Problem with Minimax M1**
- Responses were very template-like and generic
- Repeated the same format: "I'm a powerful AI agent that can execute code..."
- Lacked natural conversation flow and personalization
- Not suitable for interactive chat applications

### ✅ **Solution: Claude 3.5 Sonnet**
- **Model**: `anthropic/claude-3.5-sonnet` (verified on OpenRouter)
- **Benefits**: 
  - More natural and contextual conversations
  - Better instruction following
  - Superior reasoning capabilities
  - Proven track record for chat applications

### 📝 **Files Updated**
- **`app.py`** - Main application default model
- **`conversation_service.py`** - Conversation fallback model  
- **`memory_settings_store.py`** - Default settings model
- **`novel_writing_config.py`** - Budget model for writing
- **`openrouter_chat.py`** - Chat endpoint default & model list
- **`.env.hf`** - HF Spaces deployment config
- **`Dockerfile`** - Container environment variable

### 🔧 **Technical Details**
- ✅ OpenRouter API integration unchanged
- ✅ All authentication and base URL settings preserved
- ✅ Model name verified against OpenRouter API: `anthropic/claude-3.5-sonnet`
- ✅ Maintains backward compatibility with existing endpoints

### 💰 **Cost Considerations**
- Claude 3.5 Sonnet is more expensive than Minimax M1
- But provides significantly better user experience
- Cost vs quality trade-off justified for conversation applications

### 🎯 **Expected Results**
- More natural and engaging conversations
- Better context understanding
- Reduced template-like responses
- Improved user satisfaction

@LillyLove888 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e3ac0f4db0ea4c6a8eb5cb8cfc90ecdb)